### PR TITLE
Changed match url for admin redirection to https

### DIFF
--- a/web.config
+++ b/web.config
@@ -8,7 +8,7 @@
     <rewrite>
       <rules>
         <rule name="ForceAdminSSL" patternSyntax="ECMAScript" stopProcessing="true">
-          <match url="(ghost.*)" />
+          <match url="^(ghost\/)(.*)" />
           <conditions>
             <add input="{HTTPS}" pattern="^OFF$" />
           </conditions>


### PR DESCRIPTION
If new post have "ghost" word in url (from title by default) then post url redirects to /ghost admin panel.
