### PR TITLE
Native http / https enforcement for Ghost

### DIFF
--- a/config.js
+++ b/config.js
@@ -48,7 +48,8 @@ config = {
         },
         paths: {
             contentPath: path.join(__dirname, '/content/')
-        }
+        },
+        forceAdminSSL: false
     },
 
     // ### Production
@@ -80,7 +81,8 @@ config = {
             host: '127.0.0.1',
             // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
             port: process.env.PORT
-        }
+        },
+        forceAdminSSL: true
     },
 
     // **Developers only need to edit below here**

--- a/iisnode.yml
+++ b/iisnode.yml
@@ -2,3 +2,4 @@ node_env: production
 loggingEnabled: true
 logDirectory: iisnode
 enableXFF: true
+nodeProcessCommandLine: "D:\Program Files (x86)\nodejs\0.10.32\node.exe"

--- a/iisnode.yml
+++ b/iisnode.yml
@@ -1,4 +1,4 @@
 node_env: production
 loggingEnabled: true
 logDirectory: iisnode
-nodeProcessCommandLine: "D:\Program Files (x86)\nodejs\0.10.32\node.exe"
+enableXFF: true

--- a/web.config
+++ b/web.config
@@ -7,13 +7,6 @@
     </handlers>
     <rewrite>
       <rules>
-        <rule name="ForceAdminSSL" patternSyntax="ECMAScript" stopProcessing="true">
-          <match url="^(ghost\/)(.*)" />
-          <conditions>
-            <add input="{HTTPS}" pattern="^OFF$" />
-          </conditions>
-          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
-        </rule>
         <rule name="StaticContent">
           <action type="Rewrite" url="public{REQUEST_URI}"/>
         </rule>


### PR DESCRIPTION
There is no need to use web.config redirections and there is very important reason why it should not be udes. If You use HTTP in configuration and force HTTPS via web.config, the base url for the website is still http://. So if You in example add new user and the e-mail with registration link is sent, You have http:// in this link. There is a token in this link and it is sent via http and then redirected - it is real security bug. There was a problem with Ghost on IIS / Azure with redirection loop (310 - too many redirects) because of X-Forwarded-Proto lack in headers - so reverse proxy was not working properly for HTTPS requests on Azure Web Apps. It is quiet funny because iisnode has directive for that: enableXFF which You can call via iisnode.yml file. It is set to false by default and Ghost had a problem because of that. With enableXFF set to true everything works great natively.  
