### PR TITLE
add SSL url for admin and use azure certificate

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@
 
 var path = require('path'),
     websiteUrl = process.env.websiteUrl,
+    websiteUrlSSL = process.env.websiteUrlSSL,
     config;
 
 // Azure Feature
@@ -13,6 +14,15 @@ var path = require('path'),
 if (!websiteUrl || websiteUrl === '' ||  websiteUrl.length === 0) {
     websiteUrl = 'http://' + process.env.siteName + '.azurewebsites.net';
     console.log(websiteUrl);
+}
+
+if (!websiteUrlSSL || websiteUrlSSL === '' ||  websiteUrlSSL.length === 0) {
+    //in prod mode - forceSSL is true - so we can use the azure issued cert
+    // web apps supply some default env variables - WEBSITE_SITE_NAME and WEBSITE_HOSTNAME
+    // represent the siteName and the full DNS name respectively.
+    // using the WEBSITE_HOSTNAME we don't have to append anything and would work in ASE too.
+    websiteUrlSSL = 'https://' + process.env.WEBSITE_HOSTNAME;
+    console.log(websiteUrlSSL);
 }
 
 config = {
@@ -57,6 +67,7 @@ config = {
     // Configure your URL and mail settings here
     production: {
         url: websiteUrl,
+        urlSSL: websiteUrlSSL,
 
         // Visit http://support.ghost.org/mail for instructions
         mail: {


### PR DESCRIPTION
this allows easy admin of the site w/ out requiring a SSL certificate issued to a custom DNS name and just uses the certificate supplied by Web Apps

some questions on env variables and why not use the azure web apps provided ones as there were failures during deployment even to a Large Standard Web App. which wasn't completing the setup of the AppSettings - for `siteName`.  My suggestion is can't we use the Web Apps supplied ones instead?

btw, this is where the `urlSSL` property is described. http://support.ghost.org/config/#ssl

The scenario is I want to use a custom domain for the public facing site, but why do I need to purchase a Certificate when one exists already..

Here's more on the ghost docs.

```
If you’d like to serve the SSL version of your blog from a different URL to the one configured in url you can do so by configuring an alternative:

url: http://myblog.com,
urlSSL: https://secure.myblog.com
```
