### PR TITLE
Don't specify nodeProcessCommandLine in yml file

### DIFF
--- a/iisnode.yml
+++ b/iisnode.yml
@@ -2,4 +2,3 @@ node_env: production
 loggingEnabled: true
 logDirectory: iisnode
 enableXFF: true
-nodeProcessCommandLine: "D:\Program Files (x86)\nodejs\4.4.1\node.exe"


### PR DESCRIPTION
With the fixed Kudu (now deployed), this line is causing trouble. Now it will just do the right thing based on the package.json engine specification. This should help resolve #30
