### PR TITLE
Prevent URL rewrite for Let'sEncrypt challenge directory

### DIFF
--- a/web.config
+++ b/web.config
@@ -7,6 +7,10 @@
     </handlers>
     <rewrite>
       <rules>
+        <rule name="LetsEncrypt" stopProcessing="true">
+          <match url="\.well-known\/acme-challenge\/(.*)" />
+          <action type="None" />
+        </rule>
         <rule name="StaticContent">
           <action type="Rewrite" url="public{REQUEST_URI}"/>
         </rule>


### PR DESCRIPTION
[Let's Encrypt](https://letsencrypt.org/) challenges in the `/.well-known/acme-challenge/` directly are currently being hijacked by the Ghost URI rewrite (#67), ending in a Ghost 404 and preventing initial provisioning and automatic renewal of certificates.

This PR adds a rule to exclude this directory from the core rewrite rule and allow the challenge to succeed.